### PR TITLE
Enable debug output

### DIFF
--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
 #include <strsafe.h> /* for StringC... functions */
 
 #if !defined(NDEBUG) && defined(_MSC_VER)
-  // Detect memory leaks (MSVC only)
+  /* Detect memory leaks (MSVC only) */
   #define _CRTDBG_MAP_ALLOC
   #include <crtdbg.h>
 #endif

--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
 #include <strsafe.h> /* for StringC... functions */
 
 #if !defined(NDEBUG) && defined(_MSC_VER)
-  // for detecting memory leak (MSVC only)
+  // Detect memory leaks (MSVC only)
   #define _CRTDBG_MAP_ALLOC
   #include <crtdbg.h>
 #endif


### PR DESCRIPTION
デバッグ出力とメモリリークチェックを有効にします。

デバッグ出力はgdb, Visual Studio, WinDbgで取得可能です。
また、`wsprintf`よりも`StringCchPrintf`の方が安全だと思われるので、`<strsafe.h>`を使用します（WinXPよりも古い環境に未練はないよね）。